### PR TITLE
Make main area more responsive in accordance with drawer navigation

### DIFF
--- a/css/webkit.css
+++ b/css/webkit.css
@@ -165,17 +165,6 @@ body
 	padding: 20px;
 }
 
-.mainarea{
-	position:absolute;
-	left:300px;
-}
-.mainarea,
-.mainarea>div,
-.mainarea>div>div {
-	width:calc( 100vw - 121px );
-    height:calc( 100vh - 64px );
-	
-}
 .menuclient {
 	padding:10px;
 	width:calc( 100vw - 121px );

--- a/framework/PortalFrame/PortalFrame.bbj
+++ b/framework/PortalFrame/PortalFrame.bbj
@@ -1,3 +1,4 @@
+use ::WebKit/util/DynamicLoader.bbj::DynamicLoader
 use ::WebKit/widgets/IconTile/IconTile.bbj::IconTile
 use ::WebKit/model/Menu.bbj::Menu
 use ::WebKit/model/Menu.bbj::MenuItem
@@ -37,6 +38,10 @@ class public PortalFrame
     field public BBjString LogoUrl!
     field public BBjString LogoSmallUrl!
 
+    method public PortalFrame()
+        DynamicLoader.addLocalCSS("WebKit/framework/PortalFrame/PortalFrame.css")
+    methodend
+
     method private void initializeDrawer(Menu menu!)
         declare BBjVector menuTiles!
         declare TilesTextHeader header!
@@ -69,6 +74,7 @@ class public PortalFrame
         drawerDataModel!.setMenuTiles(menuTiles!)
         #Drawer! = new Drawer(#window!, drawerDataModel!)
         #Drawer!.setCallback(Drawer.ON_DRAWER_TILE_PRESSED, #this!, "onMenuItemClick")
+        #Drawer!.setCallback(Drawer.ON_DRAWER_STATE_CHANGED, #this!, "onDrawerToggle")
         
         header! = new TilesTextHeader(#Drawer!.getOptionalControlAboveTiles(), drawerDataModel!.getTilesTextHeader())
         
@@ -93,6 +99,7 @@ class public PortalFrame
             main! = #window!.addChildWindow(#window!.getAvailableControlID(),0,0,100,80,"",$00100800$,sysgui!.getAvailableContext())
             main!.addStyle("mainarea")
             #Main! = cast(BBjChildWindow,main!)
+            #Main!.setPanelStyle("margin-left", "320px")
              
             #initializeDrawer(#Menu!)
             REM #AccountDisplay! = CAST(BBjChildWindow,cw_top!.addChildWindow(cw_top!.getAvailableControlID(),0,0,100,80,"",$00100800$,sysgui!.getAvailableContext()))
@@ -217,6 +224,15 @@ class public PortalFrame
             #win_list!.remove(nodeId)
         fi
          
+    methodend
+
+    method public void onDrawerToggle(BBjCustomEvent ev!)
+       state = num(str(ev!.getObject()))
+       if state = 1
+          #Main!.setPanelStyle("margin-left", "320px")
+       else
+          #Main!.setPanelStyle("margin-left", "124px")
+       fi
     methodend
 
     method public void onToggleMenu(BBjEvent ev!)

--- a/framework/PortalFrame/PortalFrame.bbj
+++ b/framework/PortalFrame/PortalFrame.bbj
@@ -99,7 +99,7 @@ class public PortalFrame
             main! = #window!.addChildWindow(#window!.getAvailableControlID(),0,0,100,80,"",$00100800$,sysgui!.getAvailableContext())
             main!.addStyle("mainarea")
             #Main! = cast(BBjChildWindow,main!)
-            #Main!.setPanelStyle("margin-left", "320px")
+            #Main!.addPanelStyle("shrinked")
              
             #initializeDrawer(#Menu!)
             REM #AccountDisplay! = CAST(BBjChildWindow,cw_top!.addChildWindow(cw_top!.getAvailableControlID(),0,0,100,80,"",$00100800$,sysgui!.getAvailableContext()))
@@ -229,9 +229,11 @@ class public PortalFrame
     method public void onDrawerToggle(BBjCustomEvent ev!)
        state = num(str(ev!.getObject()))
        if state = 1
-          #Main!.setPanelStyle("margin-left", "320px")
+          #Main!.addPanelStyle("shrinked")
+          #Main!.removePanelStyle("expanded")
        else
-          #Main!.setPanelStyle("margin-left", "124px")
+          #Main!.addPanelStyle("expanded")
+          #Main!.removePanelStyle("shrinked")
        fi
     methodend
 

--- a/framework/PortalFrame/PortalFrame.css
+++ b/framework/PortalFrame/PortalFrame.css
@@ -9,6 +9,15 @@
     width: 100vw;
     height:100vh;
 }
+
+.mainarea .expanded{
+    margin-left: 124px;
+}
+
+.mainarea .shrinked{
+    margin-left: 320px;
+}
+
 @media screen and (max-width: 425px) {
     .mainarea,
     .mainarea>div,

--- a/framework/PortalFrame/PortalFrame.css
+++ b/framework/PortalFrame/PortalFrame.css
@@ -1,0 +1,21 @@
+
+.mainarea{
+	position:absolute;
+    background: #F1F1F1;
+}
+.mainarea,
+.mainarea>div,
+.mainarea>div>div {
+    width: 100vw;
+    height:100vh;
+}
+@media screen and (max-width: 425px) {
+    .mainarea,
+    .mainarea>div,
+    .mainarea>div>div {
+        margin-left: 0px !important;
+        padding-left: 10px;
+        width: 100vw;
+        height:100vh;
+    }
+}

--- a/widgets/Drawer/Drawer.bbj
+++ b/widgets/Drawer/Drawer.bbj
@@ -41,6 +41,8 @@ class public Drawer extends BBjWidget
     field private DrawerModel drawerDataModel!
 
     field public static BBjNumber ON_DRAWER_TILE_PRESSED = 122 
+
+    field public static BBjNumber ON_DRAWER_STATE_CHANGED = 1444
     
     method public Drawer(BBjWindow parent!, DrawerModel dataModel!)
         DynamicLoader.addLocalCSS("WebKit/widgets/Drawer/Drawer.css")
@@ -223,13 +225,15 @@ class public Drawer extends BBjWidget
     method public void onShadowTapped(BBjMouseDownEvent event!)
         #shadowWindow!.removeStyle("drawerShadow")
         #closeDrawer(null())
+        #fireEvent(#ON_DRAWER_STATE_CHANGED, #open!)
     methodend   
     
     method public void closeDrawer(BBjCustomEvent event!)
         #window!.addStyle("drawerClosed")
         #window!.removeStyle("drawerOpen")
+        #shadowWindow!.removeStyle("drawerShadow")
         #open! = !#open!
-        #drawerOpenIcon!.redraw(1)
+        #fireEvent(#ON_DRAWER_STATE_CHANGED, #open!)
     methodend
 
     method public void onMenuItemClick(BBjCustomEvent event!)
@@ -240,6 +244,7 @@ class public Drawer extends BBjWidget
         #window!.addStyle("drawerOpen")
         #window!.removeStyle("drawerClosed")
         #open! = !#open!
+        #fireEvent(#ON_DRAWER_STATE_CHANGED, #open!)
     methodend
     
     method public Boolean isOpen()

--- a/widgets/Drawer/Drawer.css
+++ b/widgets/Drawer/Drawer.css
@@ -96,7 +96,7 @@
 
 .drawerTilesWrapper{
     display: grid;
-    overflow: auto;
+    overflow: auto !important;
     height: calc(100vh - 381px);
 }
 

--- a/widgets/Drawer/components/DrawerMenuTile/DrawerMenuTile.bbj
+++ b/widgets/Drawer/components/DrawerMenuTile/DrawerMenuTile.bbj
@@ -44,7 +44,6 @@ class public DrawerMenuTile extends BBjWidget
     methodend
     
     method public void onDrawerMenuTile(BBjMouseDownEvent event!)
-        a = msgbox(str(#id!))
         #fireEvent(#ON_DRAWER_TILE_PRESSED, #id!) 
     methodend
     

--- a/widgets/Drawer/components/DrawerOpenIcon/DrawerOpenIcon.bbj
+++ b/widgets/Drawer/components/DrawerOpenIcon/DrawerOpenIcon.bbj
@@ -10,14 +10,14 @@ class public DrawerOpenIcon extends BBjWidget
     
     method public DrawerOpenIcon(BBjChildWindow wnd!,BBjInt id!, BBjString openIcon!)
         DynamicLoader.addLocalCSS("WebKit/widgets/Drawer/components/DrawerOpenIcon/DrawerOpenIcon.css")
-        #super!.create(wnd!,id!)
         #openIcon! = openIcon!
+        #super!.create(wnd!,id!)
     methodend
     
     method public DrawerOpenIcon(BBjChildWindow wnd!, BBjString openIcon!)
         DynamicLoader.addLocalCSS("WebKit/widgets/Drawer/components/DrawerOpenIcon/DrawerOpenIcon.css")
-        #super!.create(wnd!,wnd!.getAvailableControlID())
         #openIcon! = openIcon!
+        #super!.create(wnd!,wnd!.getAvailableControlID())
     methodend
     
     method public void redraw(Boolean init!)


### PR DESCRIPTION
This PR has fixes for - 
- Main area was not utilizing spaces when drawer is closed.
- Drawer open icon was not being correctly rendered.
- Drawer navigation and main area in mobile view was broken.
- The right border of drawer was not visible.
- Missing scrollbar on menu items overflow.

**Also removed msgbox display when a menu item is clicked**
Note - 
Still there are some static hard-coded colors and css values, which is being done by @saadnoor and will be fixed in a later PR.