### PR TITLE
Refactor-18/ Extract static footer menu

### DIFF
--- a/demo/ChileCompanyCustomerPortal/ChileCompanyCustomerPortal.bbj
+++ b/demo/ChileCompanyCustomerPortal/ChileCompanyCustomerPortal.bbj
@@ -61,11 +61,26 @@ REM s2! = m!.addMenuItem(i!,103,"Menu 2.3","This is Submenu Item 2.3","face")
 
 REM i! = m!.addMenuItem(m!.getRoot(),300,"Menu 3","This is menu item three","rowing")
 
+REM footer sub-menu creation
+declare Menu footerMenu!
+declare MenuItem footerMenuItem!
+footerMenu! = new Menu()
+footerMenuItem! = footerMenu!.addMenuItem(footerMenu!.getRoot(),400,"Home-footer1","Go to the Home - Dashboard","WebKit/demo/assets/home.svg")
+footerMenuItem!.setProgram("::WebKit/demo/ChileCompanyCustomerPortal/ChileCompanyCustomerDashboardPanel.bbj::ChileCompanyDashboardPanel")
+footerMenuItem!.setStartType(0); rem 0 = class that implements WebWidget and has a constructor that takes the parent window
 
+footerMenuItem! = footerMenu!.addMenuItem(footerMenu!.getRoot(),401,"Home-footer2","Go to the Home - Dashboard","WebKit/demo/assets/home.svg")
+footerMenuItem!.setProgram("::WebKit/demo/ChileCompanyCustomerPortal/ChileCompanyCustomerDashboardPanel.bbj::ChileCompanyDashboardPanel")
+footerMenuItem!.setStartType(0); rem 0 = class that implements WebWidget and has a constructor that takes the parent window
+
+footerMenuItem! = footerMenu!.addMenuItem(footerMenu!.getRoot(),402,"Home-footer3","Go to the Home - Dashboard","WebKit/demo/assets/home.svg")
+footerMenuItem!.setProgram("::WebKit/demo/ChileCompanyCustomerPortal/ChileCompanyCustomerDashboardPanel.bbj::ChileCompanyDashboardPanel")
+footerMenuItem!.setStartType(0); rem 0 = class that implements WebWidget and has a constructor that takes the parent window
 
 portal! = new PortalFrame()
 portal!.setUsername(login!.getUser())
 portal!.setMenu(m!)
+portal!.setFooterMenu(footerMenu!)
 portal!.setLogoUrl("WebKit/demo/assets/basislogo_white_sm.png")
 portal!.setLogoSmallUrl("WebKit/demo/assets/basislogo_white_sm.png")
 

--- a/framework/PortalFrame/PortalFrame.bbj
+++ b/framework/PortalFrame/PortalFrame.bbj
@@ -168,13 +168,13 @@ class public PortalFrame
 
     method public void onMenuItemClick(BBjCustomEvent ev!)
         nodeId=num(str(ev!.getObject()))
-        item!=#Menu!.getItem(nodeId)
+        item! = #Menu!.getItem(nodeId)
         #navigateTo(item!)
    methodend
     
     method public void onFooterMenuItemClick(BBjCustomEvent ev!)
         nodeId = num(str(ev!.getObject()))
-        item!=#FooterMenu!.getItem(nodeId)
+        item! = #FooterMenu!.getItem(nodeId)
         #navigateTo(item!)
     methodend
 

--- a/framework/PortalFrame/PortalFrame.bbj
+++ b/framework/PortalFrame/PortalFrame.bbj
@@ -5,7 +5,7 @@ use ::WebKit/model/Menu.bbj::MenuItem
 use ::WebKit/framework/MenuPanel/MenuPanel.bbj::MenuPanel
 use ::WebKit/framework/EmbedPanel/EmbedPanel.bbj::EmbedPanel
 use ::BBjWidget/BBjWidget.bbj::BBjWidget
-use ::WebKit/framework/LoginDialog.bbj::LoginDialog
+use ::WebKit/framework/LoginDialog/LoginDialog.bbj::LoginDialog
 use ::WebKit/util/ClientUtil.bbj::ClientUtil
 use ::AuthKit/profile/AccountProfile.bbj::AccountProfile
 
@@ -26,6 +26,7 @@ class public PortalFrame
     field public BBjString Username!
     field public BBjString Title!
     field public Menu Menu!
+    field public Menu FooterMenu!
     field public AccountProfile Profile!
     
     field private Boolean drawerOpen! = Boolean.FALSE
@@ -42,7 +43,7 @@ class public PortalFrame
         DynamicLoader.addLocalCSS("WebKit/framework/PortalFrame/PortalFrame.css")
     methodend
 
-    method private void initializeDrawer(Menu menu!)
+    method private void initializeDrawer(Menu menu!, Menu footerMenu!)
         declare BBjVector menuTiles!
         declare TilesTextHeader header!
 
@@ -56,6 +57,7 @@ class public PortalFrame
 
         drawerDataModel!.setAvatarUrl("/files/prodinRes/drawerAvatar.png")
         menuTiles! = new BBjVector()
+        footerMenuTiles! = new BBjVector()
 
         menuitems! = menu!.getChildren(menu!.getRoot()) 
         it! = menuitems!.iterator()
@@ -70,10 +72,29 @@ class public PortalFrame
             REM btn!.setToolTip(menuitem!.getToolTip())
             REM btn!.setCallback(BBjAPI.ON_BUTTON_PUSH,#this!,"onMenuItemClick")
         wend
+
+        footerMenuItem! = footerMenu!.addMenuItem(footerMenu!.getRoot(),498,"Switch Theme","Switch application theme","WebKit/demo/assets/home.svg")
+        footerMenuItem!.setProgram("void")
+        footerMenuItem!.setCallback("onChangeTheme")
+        footerMenuItem! = footerMenu!.addMenuItem(footerMenu!.getRoot(),499,"Log Out","Log Out","WebKit/demo/assets/log-out.png")
+        footerMenuItem!.setProgram("void")
+        footerMenuItem!.setCallback("onLogout")
+
+        footerMenuItems! = footerMenu!.getChildren(footerMenu!.getRoot())
+        it! = footerMenuItems!.iterator()
+
+        while it!.hasNext()
+            declare auto MenuItem footerMenuItem!
+            footerMenuItem! = it!.next()
+            id% = footerMenuItem!.getNodeId()
+            footerMenuTiles!.add(new DrawerMenuTileEntry(id%, footerMenuItem!.getCaption(), footerMenuItem!.getIcon()))
+        wend
+        drawerDataModel!.setFooterMenuTiles(footerMenuTiles!)
     
         drawerDataModel!.setMenuTiles(menuTiles!)
         #Drawer! = new Drawer(#window!, drawerDataModel!)
         #Drawer!.setCallback(Drawer.ON_DRAWER_TILE_PRESSED, #this!, "onMenuItemClick")
+        #Drawer!.setCallback(Drawer.ON_DRAWER_FOOTER_TILE_PRESSED, #this!, "onFooterMenuItemClick")
         #Drawer!.setCallback(Drawer.ON_DRAWER_STATE_CHANGED, #this!, "onDrawerToggle")
         #Drawer!.setCallback(Drawer.ON_LOGOUT, "logout")
         
@@ -102,7 +123,7 @@ class public PortalFrame
             #Main! = cast(BBjChildWindow,main!)
             #Main!.addStyle("shrinked")
              
-            #initializeDrawer(#Menu!)
+            #initializeDrawer(#Menu!, #FooterMenu!)
             REM #AccountDisplay! = CAST(BBjChildWindow,cw_top!.addChildWindow(cw_top!.getAvailableControlID(),0,0,100,80,"",$00100800$,sysgui!.getAvailableContext()))
             REM #AccountDisplay!.setCallback(BBjAPI.ON_POPUP_REQUEST,#this!,"onAvatarAreaClick")
             REM 
@@ -134,7 +155,6 @@ class public PortalFrame
             process_events
             
             logout:
-                #onLogout()
                 methodret 1
             
     methodend
@@ -151,6 +171,12 @@ class public PortalFrame
         item!=#Menu!.getItem(nodeId)
         #navigateTo(item!)
    methodend
+    
+    method public void onFooterMenuItemClick(BBjCustomEvent ev!)
+        nodeId = num(str(ev!.getObject()))
+        item!=#FooterMenu!.getItem(nodeId)
+        #navigateTo(item!)
+    methodend
 
    method public void navigateTo(MenuItem item!)
         if #curr_win! <> null() and !#curr_win!.isDestroyed() then
@@ -174,6 +200,12 @@ class public PortalFrame
                 #curr_win!.setVisible(1)
             else
                 pgm$ = item!.getProgram()
+                if pgm$ = "void" then
+                    callback$ = item!.getCallback()
+                    x! = null()
+                    x! = eval("#" + callback$ + "()", err=*next)
+                    methodret
+                fi
                 if pgm$>"" then
                     starttype = item!.getStartType()
                     
@@ -253,6 +285,8 @@ class public PortalFrame
     methodend
 
     method public void onLogout()
+        LoginDialog.clearRememberToken()
+        BBjAPI().postCustomEvent("logout", "")
         methodret
     methodend
 return

--- a/framework/PortalFrame/PortalFrame.bbj
+++ b/framework/PortalFrame/PortalFrame.bbj
@@ -155,6 +155,7 @@ class public PortalFrame
             process_events
             
             logout:
+                ClientUtil.setUrlAnchor("", "")
                 methodret 1
             
     methodend

--- a/framework/PortalFrame/PortalFrame.bbj
+++ b/framework/PortalFrame/PortalFrame.bbj
@@ -202,7 +202,6 @@ class public PortalFrame
                 pgm$ = item!.getProgram()
                 if pgm$ = "void" then
                     callback$ = item!.getCallback()
-                    x! = null()
                     x! = eval("#" + callback$ + "()", err=*next)
                     methodret
                 fi

--- a/model/DrawerModel.bbj
+++ b/model/DrawerModel.bbj
@@ -6,6 +6,7 @@ class public DrawerModel
     field public BBjString LogoSmallUrl!
     field public BBjString TilesTextHeader!
     field public BBjVector MenuTiles!
+    field public BBjVector FooterMenuTiles!
 
     field public BBjString DrawerOpenIcon!
     field public BBjString DrawerCloseIcon!
@@ -31,7 +32,9 @@ class public DrawerModel
         #AvatarSize! = "32px"
 
         #MenuTiles! = new BBjVector()
-        #MenuTiles!.add(new DrawerMenuTileEntry(1,"Customers","WebKit/demo/ProdinDemo/assets/users.png"))
+        #MenuTiles!.add(new DrawerMenuTileEntry(800,"Customers","WebKit/demo/ProdinDemo/assets/users.png"))
+
+        #FooterMenuTiles! = new BBjVector()
     methodend
 
     method public DrawerModel(BBjString logoUrl!, BBjString logoSmallUrl!)

--- a/model/Menu.bbj
+++ b/model/Menu.bbj
@@ -9,6 +9,7 @@ class public MenuItem
 
     field private BBjNumber StartType
     field private BBjString Program$
+    field private BBjString CallbackName$
 
     method private MenuItem()
     methodend
@@ -95,6 +96,14 @@ class public MenuItem
     
     method public BBjString getProgram()
         methodret #Program$
+    methodend
+
+    method public void setCallback(BBjString callback$)
+        #CallbackName$ = callback$
+    methodend
+
+    method public BBjString getCallback()
+        methodret #CallbackName$
     methodend
 
 classend

--- a/model/Menu.bbj
+++ b/model/Menu.bbj
@@ -9,7 +9,7 @@ class public MenuItem
 
     field private BBjNumber StartType
     field private BBjString Program$
-    field private BBjString CallbackName$
+    field private BBjString Callback$
 
     method private MenuItem()
     methodend
@@ -99,11 +99,11 @@ class public MenuItem
     methodend
 
     method public void setCallback(BBjString callback$)
-        #CallbackName$ = callback$
+        #Callback$ = callback$
     methodend
 
     method public BBjString getCallback()
-        methodret #CallbackName$
+        methodret #Callback$
     methodend
 
 classend

--- a/widgets/Drawer/Drawer.bbj
+++ b/widgets/Drawer/Drawer.bbj
@@ -42,6 +42,8 @@ class public Drawer extends BBjWidget
 
     field public static BBjNumber ON_DRAWER_TILE_PRESSED = 122 
 
+    field public static BBjNumber ON_DRAWER_FOOTER_TILE_PRESSED = 132 
+
     field public static BBjNumber ON_DRAWER_STATE_CHANGED = 1444
 
     field public static BBjNumber ON_LOGOUT = 14441
@@ -117,6 +119,7 @@ class public Drawer extends BBjWidget
             footer! = new DrawerFooter(footerWrapper!,#window!,#drawerDataModel!)
             footer!.setDockStyle("align-self","center")
             footer!.setCallback(DrawerFooter.getON_LOGOUT(), #this!, "onLogout")
+            footer!.setCallback(DrawerFooter.ON_FOOTER_TILE_PRESSED, #this!, "onFooterMenuItemClick")
             
             declare DrawerMenuTileEntry entry!
             declare BBjChildWindow spacer!
@@ -241,6 +244,10 @@ class public Drawer extends BBjWidget
 
     method public void onMenuItemClick(BBjCustomEvent event!)
         #fireEvent(#ON_DRAWER_TILE_PRESSED, event!.getObject())
+    methodend
+
+    method public void onFooterMenuItemClick(BBjCustomEvent ev!)
+        #fireEvent(#ON_DRAWER_FOOTER_TILE_PRESSED, ev!.getObject())
     methodend
     
     method public void openDrawer(BBjCustomEvent event!)

--- a/widgets/Drawer/components/DrawerFooter/DrawerFooter.bbj
+++ b/widgets/Drawer/components/DrawerFooter/DrawerFooter.bbj
@@ -5,6 +5,8 @@ use ::WebKit/framework/LoginDialog/LoginDialog.bbj::LoginDialog
 use ::WebKit/model/DrawerModel.bbj::DrawerModel
 use ::WebKit/widgets/common/CircularAvatar/CircularAvatar.bbj::CircularAvatar
 use ::WebKit/widgets/common/Overlay/Overlay.bbj::Overlay
+use ::WebKit/widgets/Drawer/components/DrawerMenuTile/DrawerMenuTile.bbj::DrawerMenuTile
+use ::WebKit/model/DrawerMenuTileEntry.bbj::DrawerMenuTileEntry
 
 class public DrawerFooter extends BBjWidget
 
@@ -20,9 +22,13 @@ class public DrawerFooter extends BBjWidget
     
     field private Overlay overlayWidget!
 
+    field private BBjVector tiles! = new BBjVector()
+
     field private DrawerModel drawerDataModel!
 
     field public static BBjNumber ON_LOGOUT = 15321
+
+    field public static BBjNumber ON_FOOTER_TILE_PRESSED = 14321
     
     method public DrawerFooter(BBjWindow parent!, BBjChildWindow drawer!,DrawerModel drawerDataModel!)
         DynamicLoader.addLocalCSS("WebKit/widgets/Drawer/components/DrawerFooter/DrawerFooter.css")
@@ -35,6 +41,7 @@ class public DrawerFooter extends BBjWidget
         #drawerDataModel! = drawerDataModel!
         #title! = drawerDataModel!.getFooterTitle()
         #subtitle! = drawerDataModel!.getFooterSubTitle()
+        #tiles! = drawerDataModel!.getFooterMenuTiles()
         #parent!= drawer!
         #setCanvas(#window!)
         #redraw(1)
@@ -93,32 +100,30 @@ class public DrawerFooter extends BBjWidget
         
         contentWrapper! = #overlay!.addChildWindow(#overlay!.getAvailableControlID(),0,0,0,0,"",$00100800$,BBjAPI().getSysGui().getAvailableContext())
         contentWrapper!.addPanelStyle("drawerFooterOverlayContentWrapper")
-  
-        settings! = contentWrapper!.addChildWindow(contentWrapper!.getAvailableControlID(),0,0,0,0,"",$00100800$,BBjAPI().getSysGui().getAvailableContext())
-        settings!.setCallback(BBjAPI.ON_MOUSE_DOWN,#this!,"onSettings")
-        settings!.addPanelStyle("drawerFooterOverlaySettingsPanel")
-        settings!.addStyle("drawerFooterOverlaySettings")
+
+        declare DrawerMenuTileEntry entry!
+        declare BBjChildWindow spacer!
+        templateRows! = ""
         
-        settingsIcon! = settings!.addImageCtrl(settings!.getAvailableControlID(),0,0,0,0,"WebKit/demo/assets/sliders.png")
-        settingsIcon!.addStyle("drawerFooterOverlaySettingsIcon")
-        
-        settingsText! = settings!.addStaticText(settings!.getAvailableControlID(),0,0,0,0,"Settings")
-        settingsText!.addStyle("drawerFooterPopUpTextStyle")
-        settingsText!.setStyle("grid-column-start","2")
-        
-        logout! = contentWrapper!.addChildWindow(contentWrapper!.getAvailableControlID(),0,0,0,0,"",$00100800$,BBjAPI().getSysGui().getAvailableContext())
-        logout!.setCallback(BBjAPI.ON_MOUSE_DOWN,#this!,"onLogout")
-        logout!.addPanelStyle("drawerFooterOverlayLogoutPanel")
-        logout!.addStyle("drawerFooterOverlayLogout")
-        
-        logoutIcon! = logout!.addImageCtrl(logout!.getAvailableControlID(),0,0,0,0,"WebKit/demo/assets/log-out.png")
-        logoutIcon!.addStyle("drawerFooterOverlayLogoutIcon")
-        
-        logoutText! = logout!.addStaticText(logout!.getAvailableControlID(),0,0,0,0,"Log Out")
-        logoutText!.addStyle("drawerFooterPopUpTextStyle")
-        logoutText!.setStyle("grid-column-start","2")
+        for i = 0 to #tiles!.size() -1
+            entry! = cast(DrawerMenuTileEntry,#tiles!.get(i))
+            tile! = new DrawerMenuTile(contentWrapper!,entry!.getID(),entry!.getIconPath(),entry!.getTitle())
+            tile!.setCallback(DrawerMenuTile.ON_DRAWER_TILE_PRESSED, #this!, "onMenuItemClick")
+            templateRows! = templateRows! + " 48px" 
+            if i <> #tiles!.size() -1 then 
+                templateRows! = templateRows! + " 12px"
+                spacer! = contentWrapper!.addChildWindow(contentWrapper!.getAvailableControlID(),0,0,0,0,"",$00100800$,BBjAPI().getSysGui().getAvailableContext())
+                spacer!.setDockStyle("height","12px")
+            endif
+        next i
+        contentWrapper!.setPanelStyle("grid-template-rows",templateRows!)
     methodend
     
+    method public void onMenuItemClick(BBjCustomEvent ev!)
+        id%  = num(str(ev!.getObject()))
+        #fireEvent(#ON_FOOTER_TILE_PRESSED, id%)
+    methodend
+
     method public void onSettings(BBjMouseDownEvent event!)
         #overlayWidget!.onOverlayDissmiss(null())
         a = msgbox("settings!!")

--- a/widgets/Drawer/components/DrawerFooter/DrawerFooter.css
+++ b/widgets/Drawer/components/DrawerFooter/DrawerFooter.css
@@ -112,7 +112,6 @@
     z-index: 99 !important;
     border-radius: 8px;
     width: 220px;
-    height: 124px;
     background-color: white;
     box-shadow: var(--bbj-shadow-l);
 }
@@ -128,8 +127,7 @@
 }
 
 .drawerFooterOverlayContentWrapper{
-    margin: 25px;
-    height: 74px;
+    margin: 10px;
     display: grid;
     grid-template-rows: 50% 50%;
 }

--- a/widgets/Drawer/components/DrawerMenuTile/DrawerMenuTile.css
+++ b/widgets/Drawer/components/DrawerMenuTile/DrawerMenuTile.css
@@ -98,6 +98,7 @@
     font-size: 14px;
     line-height: 17px;
     color: var(--bbj-color-black);
+    cursor: pointer;
 }
 
 .drawerOpen .menuWndAnimationOpen {


### PR DESCRIPTION
This PR has the following implementations and improvements - 
- Extracts statically wired footer overlay menu.
- Makes it possible to set and pass footer menu from application layer.
- Makes the menu item's cursor to pointer.

Implementation Note - 
1. For now two default values for footer menu is set, `Log Out` and `Switch Theme`. The rest is set and passed from app layer.
2. `Log Out` is wired and should work as expected.
3. `Switch Theme` is not implemented yet, waiting for the theming work to be finished.
4. Icons are not set properly, waiting for the new icon setting workflow to be finished.