### PR TITLE
Fix - Drawer icon and footer border

### DIFF
--- a/widgets/Drawer/Drawer.css
+++ b/widgets/Drawer/Drawer.css
@@ -114,7 +114,9 @@
 
 .drawerFooterWrapper{
     position: fixed;
+    /* background-color: green; */
     top: calc(100vh - 117px) !important;
+    width: 300px;
     display: grid;
     height: 117px;
 }
@@ -122,13 +124,14 @@
 .bottomDivider{
     position: fixed;
     top: calc(100vh - 116px) !important;
+    width: 300px;
 }
 
 .drawerClosed .drawerFooterWrapper{
-    top: calc(100vh - 64px) !important;
-    height: 64px;
+    top: calc(100vh - 90px) !important;
+    height: 90px;
 }
 
-.drawerClosed .bottomDivider{
-    top: calc(100vh - 64px) !important;
+.drawerClosed .bottomDivider {
+    width: 104px;
 }

--- a/widgets/Drawer/Drawer.css
+++ b/widgets/Drawer/Drawer.css
@@ -114,7 +114,6 @@
 
 .drawerFooterWrapper{
     position: fixed;
-    /* background-color: green; */
     top: calc(100vh - 117px) !important;
     width: 300px;
     display: grid;

--- a/widgets/Drawer/components/DrawerOpenIcon/DrawerOpenIcon.css
+++ b/widgets/Drawer/components/DrawerOpenIcon/DrawerOpenIcon.css
@@ -55,6 +55,6 @@
 .drawerOpenIcon{
     left: 91px;
     top: 88px;
-    position: absolute;
+    position: fixed;
     z-index: 101;
 }

--- a/widgets/common/Divider/Divider.bbj
+++ b/widgets/common/Divider/Divider.bbj
@@ -28,7 +28,6 @@ class public Divider extends BBjWidget
             #window!.setPanelStyle("margin-bottom", str(#marginBottom!))
         else 
             #window!.setPanelStyle("height", "1px")
-            #window!.setPanelStyle("width", "100%")
             #window!.setPanelStyle("background-color", "black")
         endif
     methodend


### PR DESCRIPTION
This PR fixes 
- The arrow icon that was broken when drawer is closed
- The drawer footer bottom border that was all over the content area