### PR TITLE
suggested implementation pattern

### DIFF
--- a/demo/Showcase/Showcase.bbj
+++ b/demo/Showcase/Showcase.bbj
@@ -42,7 +42,7 @@ showCaseItem! = menu!.addMenuItem(showCase!,201,"Direct - Sales - Options","Dire
 showCaseItem!.setStartType(2)
 
 menuItem! = menu!.addMenuItem(menu!.getRoot(),101,"Avatar Inital","Avatar Inital Demo","typography")
-menuItem!.setProgram("::WebKit/demo/Showcase/ShowcasePanels/AvatarInital.bbj::AvatarInital")
+menuItem!.setProgram("::WebKit/demo/Showcase/ShowcasePanels/AvatarShowcasePanel.bbj::AvatarShowcasePanel")
 menuItem!.setStartType(0)
 
 menuItem! = menu!.addMenuItem(menu!.getRoot(),100,"Dialog","Dialog Panel Demo","message-circle")

--- a/demo/Showcase/ShowcasePanels/AvatarShowcasePanel.bbj
+++ b/demo/Showcase/ShowcasePanels/AvatarShowcasePanel.bbj
@@ -5,10 +5,10 @@ use ::WebKit/util/ClientUtil.bbj::ClientUtil
 use ::WebKit/widgets/WebComponents/WebComponents.bbj::WebComponents
 use ::WebKit/widgets/WebComponents/AvatarIcon/AvatarIcon.bbj::AvatarIcon
 
-class public AvatarInital extends ShowcaseWidget
+class public AvatarShowcasePanel extends ShowcaseWidget
 
     field private BBjChildWindow window!
-    field private BBjHtmlView avatarWnd!
+    field private AvatarIcon avatarWnd!
     field private InputField avatarWidth!
     field private InputField avatarHeight!
     field private InputField AvatarName!
@@ -17,13 +17,14 @@ class public AvatarInital extends ShowcaseWidget
     field private BBjCheckBox CbCloseOutside!
     field private BBjChildWindow panel!
 
-    method public AvatarInital(BBjWindow wnd!)
+    method public AvatarShowcasePanel(BBjWindow wnd!)
         #super!(wnd!)
         
         #setTitle("Avatar Initail Demo")
         #setIntro("This demo shows the Avatar initail  stuff")
     methodend
     method public void redraw(Boolean init!)
+    
     #super!.redraw(init!)
    
     if init! then
@@ -35,7 +36,7 @@ class public AvatarInital extends ShowcaseWidget
         
         #AvatarName! = new InputField(#panel!)
         #AvatarName!.setLabel("Avatar Name")
-        #AvatarName!.setInput("Stephan Wald")
+        #AvatarName!.setInput("Donald Duck")
 
         #avatarHeight! = new InputField(#panel!)
         #avatarHeight!.setLabel("Height")
@@ -45,26 +46,22 @@ class public AvatarInital extends ShowcaseWidget
         #avatarWidth!.setLabel("Width")
         #avatarWidth!.setInput("50")
         
-        BtnShow! = #panel!.addButton(#panel!.getAvailableControlID(),0,0,0,0,"Create Avatar")
+        BtnShow! = #panel!.addButton(#panel!.getAvailableControlID(),0,0,0,0,"Update Avatar")
         BtnShow!.setStyle("display","flex")
         BtnShow!.setStyle("justify-content","flex-end")
         BtnShow!.setAttribute("theme","primary")
         BtnShow!.setAttribute("expanse","l")
-        BtnShow!.setCallback(BBjAPI().ON_BUTTON_PUSH,#this!,"onShowDialog")    
+        BtnShow!.setCallback(BBjAPI().ON_BUTTON_PUSH,#this!,"updateAvatar")    
 
+        #avatarWnd!= new  AvatarIcon(#panel!)
+        #updateAvatar(null())
     endif
+    
 methodend
 
-method public void onShowDialog(BBjButtonPushEvent ev!)
+method public void updateAvatar(BBjButtonPushEvent ev!)
 
-    if #avatarWnd! <> null() then  
-        #avatarWnd!.destroy()
-    endif
-
-    webComponents! = new AvatarIcon()
-    #avatarWnd! = CAST(BBjHtmlView, webComponents!.drawAvatarIcon(#panel!, #avatarHeight!.getInput(), #avatarWidth!.getInput(), #AvatarName!.getInput() ))
-
-    #avatarWnd!.setStyle("margin","auto")
+        #avatarWnd!.setText(#AvatarName!.getInput())
     
 methodend
     

--- a/widgets/MenuCard/MenuCard.bbj
+++ b/widgets/MenuCard/MenuCard.bbj
@@ -3,7 +3,6 @@ use ::WebKit/util/DynamicLoader.bbj::DynamicLoader
 use ::WebKit/util/Icons.bbj::Icons
 use ::WebKit/model/Menu.bbj::MenuItem
 use ::WebKit/widgets/ListTile/ListTile.bbj::ListTile
-use ::WebKit/util/Icons.bbj::Icons
 
 
 class public MenuCard extends BBjWidget 

--- a/widgets/WebComponents/AvatarIcon/AvatarIcon.bbj
+++ b/widgets/WebComponents/AvatarIcon/AvatarIcon.bbj
@@ -2,45 +2,43 @@ use ::WebKit/widgets/WebComponents/WebComponents.bbj::WebComponents
 use ::WebKit/util/ClientUtil.bbj::ClientUtil
 
 class public AvatarIcon extends WebComponents
-    field private static BBjTopLevelWindow Wnd!
+
     field public static BBjNumber ON_AVATAR_INITIAL_CLICK = 1234
-
-    method public AvatarIcon()
-
+    
+    method private AvatarIcon()
     methodend
 
-    method public BBjHtmlView drawAvatarIcon(BBjWindow wnd!,BBjInt height%, BBjInt width%, BBjString name$)
-        htmlView! = wnd!.addHtmlView(wnd!.getAvailableControlID(),0,0,300,300,"<avatar-initial height="""+str(height%)+""" width="""+str(width%)+""" name="""+name$+"""></avatar-initial>")
-        htmlView! = #configureAvatarView(htmlView!)
-        methodret htmlView!
-    methodend 
+    method public AvatarIcon(BBjWindow wnd!)
+        #super!.create(wnd!,wnd!.getAvailableControlID())
+    methodend
+    
+    method public AvatarIcon(BBjWindow wnd!, BBjInt id!)
+        #super!.create(wnd!,id!)
+    methodend
 
-    method public BBjHtmlView drawAvatarIcon(BBjWindow wnd!,BBjString height$, BBjString width$, BBjString name$)
-        htmlView! = wnd!.addHtmlView(wnd!.getAvailableControlID(),0,0,300,300,"<avatar-initial height="""+height$+""" width="""+width$+""" name="""+name$+"""></avatar-initial>")
-        htmlView! = #configureAvatarView(htmlView!)
-        methodret htmlView!
-    methodend 
-
-    method public BBjHtmlView drawAvatarIcon(BBjString height$, BBjString width$, BBjString name$)
-        sg! =  BBjAPI().openSysGui("X0")
-        #Wnd! =sg!.addWindow(95501,0,0,0,0,"",$01101083$)
-        sg!.setContext(sg!.getAvailableContext())
-        htmlView! = #Wnd!.addHtmlView(wnd!.getAvailableControlID(),0,0,300,300,"<avatar-initial height="""+height$+""" width="""+width$+""" name="""+name$+"""></avatar-initial>")
-        htmlView! = #configureAvatarView(htmlView!)
-    methodret htmlView!
-
-    method private BBjHtmlView configureAvatarView(BBjHtmlView htmlView!)
-        htmlView!.setCallback(BBjAPI.ON_NATIVE_JAVASCRIPT, #this!,"onClickAvatarInitial")
-        htmlView!.setStyle("border","none")
-        htmlView!.executeScript(#script$)
-        methodret htmlView!
-    methodend 
+   method public void redraw(Boolean f_init!)
+        #super!.redraw(f_init!)
+        
+        if f_init!>0 then
+            #htmlView!.setCallback(BBjAPI.ON_NATIVE_JAVASCRIPT, #this!,"onClickAvatarInitial")
+            #htmlView!.setStyle("border","none")
+        fi
+        
+        if #getText() <> null() then
+            rem TODO: the height and the width shall entirely come from CSS
+            txt$ = "<avatar-initial height=""50"" width=""50"" name="""+#getText()+"""></avatar-initial>"
+            #htmlView!.setText(txt$)
+        fi
+    methodend    
 
     method public void onClickAvatarInitial(BBjNativeJavaScriptEvent ev!)
         ClientUtil.consoleLog("catched the webcomponent event from BBj :)")
         #fireEvent(#ON_AVATAR_INITIAL_CLICK, ev!)
     methodend
 
-methodend 
-        
+
+    method public void setText(String txt!)
+        #super!.setText(txt!)
+        #redraw(0)
+    methodend
 classend

--- a/widgets/WebComponents/WebComponents.bbj
+++ b/widgets/WebComponents/WebComponents.bbj
@@ -3,6 +3,7 @@ use ::BBjWidget/BBjWidget.bbj::BBjWidget
 class public WebComponents extends BBjWidget
     
     field public BBjString script$
+    field protected BBjHtmlView htmlView!
 
     method public WebComponents()
 
@@ -18,6 +19,19 @@ class public WebComponents extends BBjWidget
         #script$ = #script$ + "script.setAttribute(""type"",""module"");"
 
         #script$ = #script$ + "document.head.appendChild(script)"
+        
     methodend
+    
+    
+     method public void redraw(Boolean f_init!)
+
+        #super!.redraw(f_init!)
+        
+        if (f_init!) then
+            #htmlView! = #getCanvas().addHtmlView(#getCanvas().getAvailableControlID(),1,1,1,1,"")
+            #htmlView!.executeScript(#script$)
+        fi
+        
+     methodend
         
 classend


### PR DESCRIPTION
Good morning,
this is my suggested implementation pattern. Please compare and review, try to understand
* redraw always does the initial rendering and subsequent updates, toggled by the boolean parameter
* a portion of redraw is in the webcomponents base class between the actual widget and the BBjWidget, injecting the script and creating the htmlview
* the using page creates the widget as it does with any others we wrote so far. No obscure new methods, all is now as usual
It may not be perfect but should give you the gist.
Please do one more thing: the size of the avatar webcomponent should entirely be set by client-side CSS (which of course could come from a setStyle or BBj-injected CSS file). Setting the size from code only is not viable in practice where the layout mainly would come from CSS.
